### PR TITLE
Fix cache error in console.

### DIFF
--- a/dashboard/src/apollo/apollo.ts
+++ b/dashboard/src/apollo/apollo.ts
@@ -36,6 +36,16 @@ export function createApolloClient() {
 
   return new ApolloClient({
     link: httpAuth.concat(splitLink),
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({
+      typePolicies: {
+        Guild: {
+          fields: {
+            playbackStatus: {
+              merge: true,
+            },
+          },
+        },
+      },
+    }),
   });
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/21071958/181662868-6c08a145-8011-4b9a-8b54-6942e85c0018.png)

Tell the cache that the `playbackStatus` field is directly linked to the guild instead of trying to cache it individually.